### PR TITLE
Add CudaManagedMemoryPool rmmAllocationMode.

### DIFF
--- a/src/cupoch/utility/device_vector.h
+++ b/src/cupoch/utility/device_vector.h
@@ -64,6 +64,7 @@ enum rmmAllocationMode_t {
     CudaDefaultAllocation = 0,
     PoolAllocation = 1,
     CudaManagedMemory = 2,
+    CudaManagedMemoryPool = 3,
 };
 
 template <typename T>


### PR DESCRIPTION
This mode is for Jetson devices that support unified memory access with iGPUs(intergrated GPUs).

According to https://github.com/neka-nat/cupoch/issues/26 and https://github.com/neka-nat/cupoch/issues/61 , managed memory allocation is best for jetson devices to get lower memcpy overhead.

According to this comment _Originally posted by @neka-nat in https://github.com/neka-nat/cupoch/issues/60#issuecomment-818434655_ the pointcloud processing time can be reduced with pool allocation with avoidance of dynamic memory allocation

I add a enum that is CudaManagedMemoryPool, currently it is supported by ini function

https://github.com/neka-nat/cupoch/blob/f6c91f429eaa965f7c2b7ee7d400d6086aeee015/src/cupoch/utility/device_vector.h#L81

So, I just added the missing enum. I will give it a test on jetson xavier later

Thanks. @neka-nat 