### PR TITLE
add select by index method for voxels

### DIFF
--- a/src/cupoch/geometry/voxelgrid.cu
+++ b/src/cupoch/geometry/voxelgrid.cu
@@ -19,6 +19,7 @@
  * IN THE SOFTWARE.
  **/
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/gather.h>
 
 #include "cupoch/camera/pinhole_camera_parameters.h"
 #include "cupoch/geometry/boundingvolume.h"
@@ -425,49 +426,51 @@ VoxelGrid &VoxelGrid::CarveSilhouette(
     return *this;
 }
 
-void VoxelGrid::SelectByIndex(const geometry::VoxelGrid &src,
-                       geometry::VoxelGrid &dst,
-                       const utility::device_vector<size_t> &indices, bool invert) {
+std::shared_ptr<VoxelGrid> VoxelGrid::SelectByIndex(
+                       const utility::device_vector<size_t> &indices, 
+                       bool invert) {
+    auto dst = std::make_shared<VoxelGrid>();
     if (invert) {
-        size_t n_out = src.voxels_values_.size() - indices.size();
+        size_t n_out = voxels_values_.size() - indices.size();
         utility::device_vector<size_t> sorted_indices = indices;
         thrust::sort(utility::exec_policy(0)->on(0), sorted_indices.begin(),
                         sorted_indices.end());
         utility::device_vector<size_t> inv_indices(n_out);
         thrust::set_difference(thrust::make_counting_iterator<size_t>(0),
-                                thrust::make_counting_iterator(src.voxels_values_.size()),
+                                thrust::make_counting_iterator(voxels_values_.size()),
                                 sorted_indices.begin(), sorted_indices.end(),
                                 inv_indices.begin());
 
-        dst.voxels_values_.resize(inv_indices.size());
-        dst.voxels_keys_.resize(inv_indices.size());
-        dst.voxel_size_ = src.voxel_size_;
-        dst.origin_ = src.origin_;
+        dst->voxels_values_.resize(inv_indices.size());
+        dst->voxels_keys_.resize(inv_indices.size());
+        dst->voxel_size_ = voxel_size_;
+        dst->origin_ = origin_;
 
         thrust::gather(utility::exec_policy(utility::GetStream(0))
                             ->on(utility::GetStream(0)),
-                    inv_indices.begin(), inv_indices.end(), src.voxels_values_.begin(),
-                    dst.voxels_values_.begin());
+                    inv_indices.begin(), inv_indices.end(), voxels_values_.begin(),
+                    dst->voxels_values_.begin());
         thrust::gather(utility::exec_policy(utility::GetStream(0))
                             ->on(utility::GetStream(0)),
-                    inv_indices.begin(), inv_indices.end(), src.voxels_keys_.begin(),
-                    dst.voxels_keys_.begin());
-        cudaSafeCall(cudaDeviceSynchronize());                        
+                    inv_indices.begin(), inv_indices.end(), voxels_keys_.begin(),
+                    dst->voxels_keys_.begin());
+        cudaSafeCall(cudaDeviceSynchronize());
 
     } else {
-        dst.voxels_values_.resize(indices.size());
-        dst.voxels_keys_.resize(indices.size());
-        dst.voxel_size_ = src.voxel_size_;
-        dst.origin_ = src.origin_;
+        dst->voxels_values_.resize(indices.size());
+        dst->voxels_keys_.resize(indices.size());
+        dst->voxel_size_ = voxel_size_;
+        dst->origin_ = origin_;
 
         thrust::gather(utility::exec_policy(utility::GetStream(0))
                             ->on(utility::GetStream(0)),
-                    indices.begin(), indices.end(), src.voxels_values_.begin(),
-                    dst.voxels_values_.begin());
+                    indices.begin(), indices.end(), voxels_values_.begin(),
+                    dst->voxels_values_.begin());
         thrust::gather(utility::exec_policy(utility::GetStream(0))
                             ->on(utility::GetStream(0)),
-                    indices.begin(), indices.end(), src.voxels_keys_.begin(),
-                    dst.voxels_keys_.begin());
+                    indices.begin(), indices.end(), voxels_keys_.begin(),
+                    dst->voxels_keys_.begin());
         cudaSafeCall(cudaDeviceSynchronize());
     }
+    return dst;
 }

--- a/src/cupoch/geometry/voxelgrid.h
+++ b/src/cupoch/geometry/voxelgrid.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <thrust/transform_reduce.h>
-#include <thrust/gather.h>
 
 #include <Eigen/Core>
 #include <memory>
@@ -157,13 +156,12 @@ public:
             const camera::PinholeCameraParameters &camera_parameter,
             bool keep_voxels_outside_image);
     
-    /// Selects all voxels from src by given indices and copies them to dst.
-    /// if invert is set to true, deselects all voxels given by indices, copies remaing voxels
-    /// from src to dst
-    void SelectByIndex(const geometry::VoxelGrid &src,
-                       geometry::VoxelGrid &dst,
-                       const utility::device_vector<size_t> &indices, 
-                       bool invert);        
+    /// Selects all voxels from src by given \param indices and copies them to temp grid.
+    /// if \param invert is set to true, deselects all voxels given by \param indices, copies remaing voxels
+    /// from this to temp grid and returns it.
+    std::shared_ptr<VoxelGrid> SelectByIndex(
+                                              const utility::device_vector<size_t> &indices, 
+                                              bool invert);        
 
     // Creates a voxel grid where every voxel is set (hence dense). This is a
     // useful starting point for voxel carving.


### PR DESCRIPTION
Sometimes it is useful to select/deselect voxels given by indices, especially after performing a collision check, for further processing the colliding or non-colliding voxels 