### PR TITLE
fix bug when cropping with oriented bbox

### DIFF
--- a/src/cupoch/geometry/boundingvolume.cu
+++ b/src/cupoch/geometry/boundingvolume.cu
@@ -51,7 +51,7 @@ struct check_within_oriented_bounding_box_functor {
     __device__ bool operator()(
             const thrust::tuple<int, Eigen::Vector3f> &x) const {
         const Eigen::Vector3f &point = thrust::get<1>(x);
-        return (test_plane(box_points_[0], box_points_[1], box_points_[3],
+        return ((test_plane(box_points_[0], box_points_[1], box_points_[3],
                            point) <= 0 &&
                 test_plane(box_points_[0], box_points_[5], box_points_[3],
                            point) >= 0 &&
@@ -62,7 +62,19 @@ struct check_within_oriented_bounding_box_functor {
                 test_plane(box_points_[3], box_points_[4], box_points_[5],
                            point) <= 0 &&
                 test_plane(box_points_[0], box_points_[1], box_points_[7],
-                           point) >= 0);
+                           point) >= 0) ||
+                (test_plane(box_points_[0], box_points_[1], box_points_[3],
+                           point) >= 0 &&
+                test_plane(box_points_[0], box_points_[5], box_points_[3],
+                           point) <= 0 &&
+                test_plane(box_points_[2], box_points_[5], box_points_[7],
+                           point) >= 0 &&
+                test_plane(box_points_[1], box_points_[4], box_points_[7],
+                           point) <= 0 &&
+                test_plane(box_points_[3], box_points_[4], box_points_[5],
+                           point) >= 0 &&
+                test_plane(box_points_[0], box_points_[1], box_points_[7],
+                           point) <= 0));
     }
 };
 


### PR DESCRIPTION
I have fixed a crucial bug in the `check_within_oriented_bounding_box_functor` in `src/cupoch/geometry/boundingvolume.cu`. This bug was affecting on cropping operations for oriented bounding boxes under specific rotations.

**Bug Description:**
- The original implementation failed to handle cases where the bounding box's rotation resulted in all plane conditions having inverted signs.
- This oversight led to certain rotations of the bounding box not cropping points correctly, as the function missed scenarios where all plane conditions were opposite to the expected.

**Implemented Fix:**
- I updated the conditional checks in the `operator()` method to handle cases where the bounding box's rotation inverts the signs of all plane conditions.
- This update ensures that points are correctly evaluated for cropping, irrespective of the box's rotation, thereby addressing the previously missed scenarios.

**Testing and Validation:**
- Simple comparative tests were conducted between the original and the modified code.
- These tests revealed that the original implementation failed to correctly crop points for certain bounding box rotations.
- The modified version successfully handled these scenarios, ensuring accurate cropping across all tested rotations.

I believe this fix significantly enhances the bounding box functionality and am eager to hear your feedback or any further suggestions for improvements.