### PR TITLE
Fix: Security vulnerability in decomp

### DIFF
--- a/third_party/libjpeg-turbo/libjpeg-turbo/tjbench.c
+++ b/third_party/libjpeg-turbo/libjpeg-turbo/tjbench.c
@@ -171,7 +171,7 @@ static int decomp(unsigned char *srcBuf, unsigned char **jpegBuf,
   }
   /* Set the destination buffer to gray so we know whether the decompressor
      attempted to write to it */
-  memset(dstBuf, 127, pitch * scaledh);
+  memset(dstBuf, 127, (size_t)pitch * scaledh);
 
   if (doYUV) {
     int width = doTile ? tilew : scaledw;
@@ -193,7 +193,7 @@ static int decomp(unsigned char *srcBuf, unsigned char **jpegBuf,
     double start = getTime();
 
     for (row = 0, dstPtr = dstBuf; row < ntilesh;
-         row++, dstPtr += pitch * tileh) {
+         row++, dstPtr += (size_t)pitch * tileh) {
       for (col = 0, dstPtr2 = dstPtr; col < ntilesw;
            col++, tile++, dstPtr2 += ps * tilew) {
         int width = doTile ? min(tilew, w - col * tilew) : scaledw;


### PR DESCRIPTION
This PR fixes a security vulnerability in `decomp()` that was cloned from libjpeg-turbo/libjpeg-turbo but did not receive the security patch.

**Vulnerability Details:**
- **Affected Function**: `decomp()` in `third_party/libjpeg-turbo/libjpeg-turbo/tjbench.c`
- **Original Fix**: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/c30b1e72dac76343ef9029833d1561de07d29bad

**What this PR does:**
This PR applies the same security patch that was applied to the original repository to eliminate the vulnerability in the cloned code.

**References:**
- https://github.com/libjpeg-turbo/libjpeg-turbo/commit/c30b1e72dac76343ef9029833d1561de07d29bad

Please review and merge this PR to ensure your repository is protected against this vulnerability.
