### PR TITLE
[ROCm] Add AMD GPU support via HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
     "Installation directory for CMake files")
 
+option(USE_HIP                   "Build with HIP for AMD GPUs (ROCm)"       OFF)
 option(BUILD_UNIT_TESTS          "Build the Cupoch unit tests"              ON)
 option(BUILD_EIGEN3              "Use the Eigen3 that comes with Cupoch"    ON)
 option(BUILD_GLEW                "Build glew from source"                   OFF)
@@ -58,7 +59,11 @@ option(BUILD_PNG                 "Build png from source"                    OFF)
 option(BUILD_JPEG                "Build jpeg-turbo from source"             ON)
 option(BUILD_PYBIND11            "Build pybind11 from source"               ON)
 option(BUILD_PYTHON_MODULE       "Build the python module"                  ON)
-option(USE_RMM                   "Use rmm library(fast memory allocator)"   ON)
+include(CMakeDependentOption)
+# RMM (RAPIDS Memory Manager) is CUDA-only. Force it OFF (and hide it) for the HIP
+# build, where the allocator falls back to thrust::device_vector
+# (see utility/device_vector.h); the user never has to pass -DUSE_RMM=OFF.
+cmake_dependent_option(USE_RMM   "Use rmm library(fast memory allocator)"   ON "NOT USE_HIP" OFF)
 option(STATIC_WINDOWS_RUNTIME    "Use static (MT/MTd) Windows runtime"      OFF)
 option(CMAKE_USE_RELATIVE_PATHS  "If true, cmake will use relative paths"   ON)
 
@@ -159,6 +164,77 @@ elseif (UNIX)
     message(STATUS "Compiling on Unix")
 endif ()
 
+if (USE_HIP)
+  # --- ROCm/HIP build ----------------------------------------------------
+  # cupoch uses the legacy FindCUDA module (cuda_add_library + CUDA_NVCC_FLAGS).
+  # Rather than rewrite every module's CMakeLists, provide a cuda_add_library()
+  # shim that creates a normal library and marks the .cu sources LANGUAGE HIP,
+  # so each `cuda_add_library(cupoch_xxx ...)` call is untouched and the NVIDIA
+  # path stays unchanged. host C++ is compiled by the host compiler; only
+  # .cu translation units see the HIP toolchain.
+  if(NOT DEFINED CMAKE_HIP_COMPILER AND EXISTS "/opt/rocm/llvm/bin/clang++")
+    set(CMAKE_HIP_COMPILER "/opt/rocm/llvm/bin/clang++")
+  endif()
+  # enable_language(HIP) honors -DCMAKE_HIP_ARCHITECTURES, otherwise auto-detects
+  # the host GPU(s), and errors on a no-GPU build host.
+  enable_language(HIP)
+  # On Windows with clang, the MSVC block above does not fire, so no -std=c++17
+  # is set globally. rocPRIM (pulled in by rocThrust) requires C++17; enforce it
+  # for all HIP and CXX TUs when the compiler is clang-based on Windows.
+  if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_HIP_STANDARD 17)
+    set(CMAKE_HIP_STANDARD_REQUIRED ON)
+    # clang-on-Windows does not enter the MSVC block above, so set the two Windows
+    # definitions the HIP build needs here (the NVIDIA MSVC build never sees them):
+    # NOMINMAX keeps windows.h min/max macros from shadowing Eigen/STL, and
+    # _USE_MATH_DEFINES exposes M_PI / M_PI_2 from <cmath>.
+    add_definitions(-DNOMINMAX -D_USE_MATH_DEFINES)
+  endif ()
+  find_package(hip REQUIRED)
+
+  # IMPORTANT: link only hip::host (runtime), never hip::device or roc::rocthrust
+  # as a target dependency. hip::device carries `-x hip --offload-arch=...` as
+  # INTERFACE_COMPILE_OPTIONS that propagate to ALL languages of a consuming
+  # target -- including the host .cpp files in cuda_add_library targets -- which
+  # makes g++ choke on `--offload-arch`. The .cu files are marked LANGUAGE HIP and
+  # compiled by the HIP toolchain on their own; rocThrust/hipCUB are header-only
+  # under /opt/rocm/include (already on the HIP compiler's default search path),
+  # so they need no link-time target.
+  macro(cuda_add_library _name)
+    set(_cupoch_hip_srcs "")
+    set(_cupoch_hip_opts "")
+    foreach(_arg ${ARGN})
+      if(_arg STREQUAL "STATIC" OR _arg STREQUAL "SHARED" OR _arg STREQUAL "MODULE")
+        list(APPEND _cupoch_hip_opts ${_arg})
+      else()
+        list(APPEND _cupoch_hip_srcs ${_arg})
+      endif()
+    endforeach()
+    add_library(${_name} ${_cupoch_hip_opts} ${_cupoch_hip_srcs})
+    # Mark every source LANGUAGE HIP, not just .cu. cupoch's GPU library targets
+    # mix .cu and .cpp, and several .cpp include rocThrust/stdgpu headers (e.g.
+    # utility/helper.cpp via helper.h) that only the HIP (clang) compiler can
+    # parse. Under nvcc the whole cuda_add_library was driven by the CUDA
+    # compiler, so .cpp there could include CUDA Thrust too; mirror that by
+    # compiling all of these TUs with the HIP toolchain (clang compiles plain
+    # host C++ unchanged).
+    foreach(_src ${_cupoch_hip_srcs})
+      if(_src MATCHES "\\.(cu|cpp)$")
+        set_source_files_properties(${_src} PROPERTIES LANGUAGE HIP)
+      endif()
+    endforeach()
+    set_target_properties(${_name} PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+    target_link_libraries(${_name} hip::host)
+  endmacro()
+
+  # CUDA_LIBRARIES/CUDA_INCLUDE_DIRS are referenced by the existing CMake; map
+  # them to the HIP runtime so those lines keep working without edits.
+  set(CUDA_LIBRARIES hip::host)
+  set(CUDA_INCLUDE_DIRS "")
+  add_compile_definitions(USE_HIP __HIP_PLATFORM_AMD__)
+else ()
 find_package(CUDA REQUIRED)
 enable_language(CUDA)
 if(NOT CMAKE_CUDA_ARCHITECTURES)
@@ -203,10 +279,16 @@ set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
     -Xcudafe "--diag_suppress=integer_sign_change"
     -Xcudafe "--diag_suppress=partial_override"
     -Xcudafe "--diag_suppress=virtual_function_decl_hidden")
+endif ()  # USE_HIP
+
 if (USE_RMM)
+    # RMM (RAPIDS Memory Manager) is CUDA-only; the HIP build uses USE_RMM=OFF and
+    # falls back to thrust::device_vector (see utility/device_vector.h).
     add_definitions(-DUSE_RMM)
     add_definitions(-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
+    if (NOT USE_HIP)
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
+    endif ()
 endif ()
 
 # 3rd-party projects that are added with external_project_add will be installed
@@ -216,13 +298,22 @@ endif ()
 # - Libraries: cupoch/build/3rdparty_install/lib/extern_lib.a
 set(3RDPARTY_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/3rdparty_install")
 
-add_subdirectory(third_party)
+if (USE_HIP)
+    # Full ROCm/HIP build: the same module set as the NVIDIA build, minus only
+    # the bits that are genuinely non-viable on ROCm (decided automatically, not
+    # behind a user flag). The third-party graph is assembled by a HIP-specific
+    # file rather than third_party/CMakeLists.txt (which bakes in the legacy
+    # FindCUDA assumptions); see cmake/cupoch_hip_3rdparty.cmake.
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cupoch_hip_modules.cmake)
+else ()
+    add_subdirectory(third_party)
 
-include_directories(
-    SYSTEM
-    ${3RDPARTY_INCLUDE_DIRS}
-)
+    include_directories(
+        SYSTEM
+        ${3RDPARTY_INCLUDE_DIRS}
+    )
 
-include_directories(src)
-add_subdirectory(src)
-add_subdirectory(examples)
+    include_directories(src)
+    add_subdirectory(src)
+    add_subdirectory(examples)
+endif ()

--- a/README.md
+++ b/README.md
@@ -77,6 +77,31 @@ cd build
 cmake ..; make install-pip-package -j
 ```
 
+### Build with ROCm (AMD GPUs)
+
+cupoch also builds on AMD GPUs with [ROCm](https://rocm.docs.amd.com/) by
+configuring with `-DUSE_HIP=ON`. This builds the full library set (the GPU
+compute modules, the OpenGL visualization, and the Python module), the same
+modules as the CUDA build.
+
+```
+git clone https://github.com/neka-nat/cupoch.git --recurse
+cd cupoch
+mkdir build
+cd build
+cmake .. -DUSE_HIP=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build . -j
+```
+
+The GPU architecture is detected automatically; override it for cross-compiling
+with `-DCMAKE_HIP_ARCHITECTURES=gfx90a` (or `gfx1100`, etc.). The NVIDIA CUDA
+build is unchanged: `USE_HIP` defaults to `OFF`.
+
+Two features are not available on the ROCm build: the libSGM-based stereo
+matcher in `imageproc`, and `ScalableTSDFVolume` (its device hash map stores a
+volume unit too large for the AMD GPU scratch limit; use `UniformTSDFVolume`
+instead). Both are skipped automatically; the rest of the library is unaffected.
+
 ### Installation for Jetson Nano
 You can also install cupoch using pip on Jetson Nano.
 Please set up Jetson using [jetpack](https://developer.nvidia.com/embedded/jetpack) and install some packages with apt.

--- a/cmake/cupoch_hip_3rdparty.cmake
+++ b/cmake/cupoch_hip_3rdparty.cmake
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# ROCm/HIP port author: Jeff Daily <jeff.daily@amd.com>
+#
+# Third-party dependency assembly for the full ROCm/HIP build. The HIP build
+# does NOT go through third_party/CMakeLists.txt: that file builds the GPU deps
+# (stdgpu, flann CUDA kdtree, libSGM) with the legacy FindCUDA assumptions and
+# would need every one made HIP-aware in-line. Instead this file builds the
+# same dependency set the HIP module graph needs, with the stdgpu/flann HIP
+# bring-up already proven by the core path plus the host libraries the io /
+# kinematics / visualization modules require. The NVIDIA build is unaffected
+# (it never includes this file).
+
+set(_tp ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
+
+# --- header-only / host deps ------------------------------------------------
+set(EIGEN3_INCLUDE_DIRS ${_tp}/eigen)
+set(dlpack_INCLUDE_DIRS ${_tp}/dlpack/include)
+set(tomasakeninemoeller_INCLUDE_DIRS ${_tp}/tomasakeninemoeller)
+set(flann_INCLUDE_DIRS ${_tp})
+set(lbvh_INCLUDE_DIRS ${_tp}/lbvh)
+set(lbvh_index_INCLUDE_DIRS ${_tp}/lbvh_index)
+
+# spdlog (built as the project does, header set exported)
+set(SPDLOG_MASTER_PROJECT OFF)
+add_subdirectory(${_tp}/spdlog ${CMAKE_BINARY_DIR}/spdlog)
+set(spdlog_INCLUDE_DIRS ${_tp}/spdlog/include)
+
+# jsoncpp (utility/ijson_convertible + camera + io)
+add_subdirectory(${_tp}/jsoncpp ${CMAKE_BINARY_DIR}/jsoncpp)
+set(JSONCPP_INCLUDE_DIRS ${_tp}/jsoncpp/include)
+set(JSONCPP_LIBRARIES jsoncpp)
+
+# liblzf (io: compressed voxel/feature blobs)
+file(GLOB LIBLZF_SOURCE_FILES "${_tp}/liblzf/*.c")
+add_library(liblzf ${LIBLZF_SOURCE_FILES})
+target_include_directories(liblzf PUBLIC ${_tp}/liblzf)
+set(liblzf_INCLUDE_DIRS ${_tp}/liblzf)
+set(liblzf_LIBRARIES liblzf)
+
+# rply (io: PLY point clouds / meshes)
+add_library(rply ${_tp}/rply/rply.c)
+set(rply_INCLUDE_DIRS ${_tp}/rply)
+set(rply_LIBRARIES rply)
+
+# tinyobjloader (io: OBJ meshes)
+add_library(tinyobjloader STATIC ${_tp}/tinyobjloader/tiny_obj_loader.cc)
+target_include_directories(tinyobjloader PUBLIC ${_tp}/tinyobjloader)
+set(tinyobjloader_INCLUDE_DIRS ${_tp}/tinyobjloader)
+set(tinyobjloader_LIBRARIES tinyobjloader)
+
+# zlib + libpng (io: PNG images). Build from the vendored sources (as the
+# project's own third_party/CMakeLists.txt does) so the build does not depend on
+# a system libpng matching the vendored headers. The vendored zlib/libpng define
+# the targets `zlib` and `png` (libpng's CMakeLists reads ZLIB_LIBRARY/_INCLUDE
+# from the parent scope to find the just-built zlib).
+add_subdirectory(${_tp}/zlib ${CMAKE_BINARY_DIR}/zlib)
+set(ZLIB_INCLUDE_DIR ${_tp}/zlib ${CMAKE_BINARY_DIR}/zlib)
+set(ZLIB_LIBRARY zlib)
+add_subdirectory(${_tp}/libpng ${CMAKE_BINARY_DIR}/libpng)
+set(PNG_INCLUDE_DIRS ${_tp}/libpng ${CMAKE_BINARY_DIR}/libpng)
+set(PNG_LIBRARIES png zlib)
+
+# libjpeg-turbo (io: classic libjpeg API via <jpeglib.h>). Build the vendored
+# source in-tree (add_subdirectory) rather than as an ExternalProject: the
+# project's libjpeg-turbo.cmake hard-codes a source path relative to
+# third_party/, and the static jpeg target plus its generated jconfig/jpeglib
+# headers are all we need here.
+set(ENABLE_SHARED OFF CACHE BOOL "" FORCE)
+set(ENABLE_STATIC ON CACHE BOOL "" FORCE)
+set(WITH_TURBOJPEG OFF CACHE BOOL "" FORCE)
+# NASM is not a build dependency here; disable the SIMD path so libjpeg-turbo
+# does not enable_language(ASM_NASM) and fail when nasm is absent.
+set(WITH_SIMD OFF CACHE BOOL "" FORCE)
+set(REQUIRE_SIMD OFF CACHE BOOL "" FORCE)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# libjpeg-turbo's CMakeLists.txt uses CMAKE_INSTALL_DOCDIR unconditionally.
+# On non-UNIX platforms CMake's GNUInstallDirs may leave it empty; set a
+# fallback so libjpeg-turbo's install() calls don't fail at configure time.
+if(NOT CMAKE_INSTALL_DOCDIR)
+    set(CMAKE_INSTALL_DOCDIR "doc" CACHE PATH "" FORCE)
+endif()
+add_subdirectory(${_tp}/libjpeg-turbo/libjpeg-turbo ${CMAKE_BINARY_DIR}/libjpeg-turbo)
+set(JPEG_TURBO_INCLUDE_DIRS ${_tp}/libjpeg-turbo/libjpeg-turbo
+    ${CMAKE_BINARY_DIR}/libjpeg-turbo)
+set(JPEG_TURBO_LIBRARIES jpeg-static)
+
+# urdfdom (kinematics: URDF robot model parser, host C++)
+set(CONSOLE_BRIDGE_MAJOR_VERSION 1)
+set(CONSOLE_BRIDGE_MINOR_VERSION 0)
+set(CONSOLE_BRIDGE_PATCH_VERSION 1)
+include(GenerateExportHeader)
+add_library(console_bridge ${_tp}/urdfdom/urdf_parser/src/console.cpp)
+target_include_directories(console_bridge PUBLIC
+    $<BUILD_INTERFACE:${_tp}/urdfdom/urdf_parser/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+generate_export_header(console_bridge EXPORT_MACRO_NAME CONSOLE_BRIDGE_DLLAPI)
+file(GLOB_RECURSE URDFDOM_SOURCES ${_tp}/urdfdom/urdf_parser/src/*.cpp)
+list(FILTER URDFDOM_SOURCES EXCLUDE REGEX "src/console\\.cpp$")
+add_library(urdfdom STATIC ${URDFDOM_SOURCES})
+target_include_directories(urdfdom PRIVATE
+    ${_tp}/urdfdom/urdf_parser/include
+    ${_tp}/urdfdom/urdf_parser/include/tinyxml)
+target_link_libraries(urdfdom console_bridge)
+set(urdfdom_INCLUDE_DIR
+    ${_tp}/urdfdom/urdf_parser/include
+    ${_tp}/urdfdom/urdf_parser/include/tinyxml
+    ${CMAKE_CURRENT_BINARY_DIR})
+set(urdfdom_LIBRARIES urdfdom)
+
+# --- stdgpu (GPU STL, HIP backend) ------------------------------------------
+set(STDGPU_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+set(STDGPU_BUILD_TESTS OFF CACHE INTERNAL "")
+set(STDGPU_BUILD_BENCHMARKS OFF CACHE INTERNAL "")
+set(STDGPU_SETUP_COMPILER_FLAGS OFF CACHE INTERNAL "")
+set(STDGPU_BACKEND STDGPU_BACKEND_HIP CACHE STRING "" FORCE)
+# stdgpu 1.3.0 bitrots against ROCm 7: its bundled Findthrust requires CUDA-only
+# CUB/libcudacxx, and it pins find_package(hip 5.1) which the SameMajorVersion
+# ROCm 7 hip-config rejects. Resolve both from cupoch's side (no submodule edit).
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hip_thrust)
+list(PREPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/rocm_hip_compat)
+add_subdirectory(${_tp}/stdgpu ${CMAKE_BINARY_DIR}/stdgpu)
+# stdgpu compiles its generic impl/*.cpp with the CXX compiler, but on the HIP
+# backend those include rocThrust -> rocPRIM headers only the HIP (clang)
+# compiler can parse; force every stdgpu TU to LANGUAGE HIP (absolute paths).
+get_target_property(_stdgpu_srcs stdgpu SOURCES)
+get_target_property(_stdgpu_srcdir stdgpu SOURCE_DIR)
+set(_stdgpu_hip_srcs "")
+foreach(_s ${_stdgpu_srcs})
+    if(_s MATCHES "\\.(cpp|cu)$")
+        if(NOT IS_ABSOLUTE "${_s}")
+            set(_s "${_stdgpu_srcdir}/${_s}")
+        endif()
+        list(APPEND _stdgpu_hip_srcs "${_s}")
+    endif()
+endforeach()
+set_source_files_properties(${_stdgpu_hip_srcs} TARGET_DIRECTORY stdgpu
+                            PROPERTIES LANGUAGE HIP)
+if (NOT WIN32)
+    target_compile_options(stdgpu PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-fPIC>)
+endif ()
+set(stdgpu_INCLUDE_DIRS ${_tp}/stdgpu/src ${CMAKE_BINARY_DIR}/stdgpu/src/stdgpu/include)
+set(stdgpu_LIBRARIES stdgpu)
+
+# --- OpenGL renderer deps (visualization; attempted when OpenGL is present) --
+# ROCm ships the hipGraphics* GL<->HIP interop API, so the GL renderer is a real
+# target on AMD. It needs an OpenGL context (GLFW), the GL loader (GLEW) and the
+# imgui overlay. GLFW + OpenGL come from the system; GLEW + imgui build from the
+# vendored sources. If OpenGL is absent the visualization module is skipped
+# automatically (decided in cupoch_hip_modules.cmake).
+find_package(OpenGL QUIET)
+set(CUPOCH_HIP_BUILD_VISUALIZATION OFF)
+find_package(glfw3 QUIET)
+if (OPENGL_FOUND)
+    set(CUPOCH_HIP_BUILD_VISUALIZATION ON)
+
+    add_subdirectory(${_tp}/glew ${CMAKE_BINARY_DIR}/glew)
+    set(GLEW_INCLUDE_DIRS ${_tp}/glew/include)
+    set(GLEW_LIBRARIES glew)
+
+    # Prefer a system GLFW; fall back to the vendored copy.
+    if (glfw3_FOUND OR TARGET glfw)
+        set(GLFW_LIBRARIES glfw)
+        set(GLFW_INCLUDE_DIRS ${OPENGL_INCLUDE_DIR})
+    else ()
+        set(GLFW_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+        set(GLFW_BUILD_TESTS OFF CACHE INTERNAL "")
+        set(GLFW_BUILD_DOCS OFF CACHE INTERNAL "")
+        add_subdirectory(${_tp}/GLFW ${CMAKE_BINARY_DIR}/GLFW)
+        set(GLFW_LIBRARIES glfw)
+        # The vendored GLFW headers are in third_party/GLFW/include; also
+        # include OPENGL_INCLUDE_DIR (may be empty on Windows but harmless).
+        set(GLFW_INCLUDE_DIRS ${_tp}/GLFW/include ${OPENGL_INCLUDE_DIR})
+    endif ()
+
+    add_library(imgui STATIC
+        ${_tp}/imgui/imgui.cpp
+        ${_tp}/imgui/imgui_draw.cpp
+        ${_tp}/imgui/imgui_tables.cpp
+        ${_tp}/imgui/imgui_widgets.cpp
+        ${_tp}/imgui/backends/imgui_impl_glfw.cpp
+        ${_tp}/imgui/backends/imgui_impl_opengl3.cpp)
+    target_include_directories(imgui PRIVATE ${_tp}/imgui ${GLFW_INCLUDE_DIRS}
+                               ${GLEW_INCLUDE_DIRS})
+    target_include_directories(imgui PUBLIC ${_tp})
+    set(imgui_INCLUDE_DIRS ${_tp} ${_tp}/imgui)
+    set(imgui_LIBRARIES imgui)
+endif ()
+
+# --- flann CUDA kdtree (knn / geometry normals) -----------------------------
+file(GLOB_RECURSE CUPOCH_FLANN_CU ${_tp}/flann/*.cu)
+cuda_add_library(flann_cuda_s STATIC ${CUPOCH_FLANN_CU})
+target_include_directories(flann_cuda_s BEFORE PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/cmake/flann_hip_compat)
+target_compile_options(flann_cuda_s PRIVATE
+                       -include ${CMAKE_CURRENT_SOURCE_DIR}/cmake/flann_hip_compat/flann_hip_prelude.h)
+target_include_directories(flann_cuda_s PRIVATE ${flann_INCLUDE_DIRS} ${spdlog_INCLUDE_DIRS})
+target_compile_definitions(flann_cuda_s PRIVATE -DFLANN_USE_CUDA)
+set(FLANN_LIBRARIES flann_cuda_s)
+
+# --- exported dependency lists ----------------------------------------------
+set(3RDPARTY_INCLUDE_DIRS
+    ${EIGEN3_INCLUDE_DIRS}
+    ${flann_INCLUDE_DIRS}
+    ${spdlog_INCLUDE_DIRS}
+    ${dlpack_INCLUDE_DIRS}
+    ${JSONCPP_INCLUDE_DIRS}
+    ${stdgpu_INCLUDE_DIRS}
+    ${lbvh_INCLUDE_DIRS}
+    ${lbvh_index_INCLUDE_DIRS}
+    ${tomasakeninemoeller_INCLUDE_DIRS}
+    ${liblzf_INCLUDE_DIRS}
+    ${rply_INCLUDE_DIRS}
+    ${tinyobjloader_INCLUDE_DIRS}
+    ${PNG_INCLUDE_DIRS}
+    ${JPEG_TURBO_INCLUDE_DIRS}
+    ${urdfdom_INCLUDE_DIR}
+    ${GLEW_INCLUDE_DIRS}
+    ${GLFW_INCLUDE_DIRS}
+    ${imgui_INCLUDE_DIRS}
+)
+set(3RDPARTY_LIBRARIES
+    ${FLANN_LIBRARIES}
+    ${stdgpu_LIBRARIES}
+    ${JSONCPP_LIBRARIES}
+    ${liblzf_LIBRARIES}
+    ${rply_LIBRARIES}
+    ${tinyobjloader_LIBRARIES}
+    ${PNG_LIBRARIES}
+    ${JPEG_TURBO_LIBRARIES}
+    ${urdfdom_LIBRARIES}
+    ${GLEW_LIBRARIES}
+    ${GLFW_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    ${imgui_LIBRARIES}
+    ${CUDA_LIBRARIES}
+)

--- a/cmake/cupoch_hip_modules.cmake
+++ b/cmake/cupoch_hip_modules.cmake
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# ROCm/HIP port author: Jeff Daily <jeff.daily@amd.com>
+#
+# Full ROCm/HIP module assembly. Builds every cupoch module that is portable to
+# HIP. The two modules with hard external coupling are decided here, not by a
+# user flag:
+#   - visualization: needs an OpenGL context + GL<->HIP interop. ROCm ships the
+#     hipGraphics* GL-interop API; visualization is attempted when OpenGL/GLEW/
+#     GLFW are available and disabled automatically otherwise.
+#   - imageproc: a thin wrapper over the CUDA-only libSGM stereo library, which
+#     is not ported to HIP. Disabled automatically.
+# Everything else (collision, integration, io, kinematics, kinfu, odometry,
+# planning, registration + the core utility/camera/knn/geometry) builds on HIP.
+
+configure_file("${PROJECT_SOURCE_DIR}/src/cupoch/cupoch_config.h.in"
+               "${PROJECT_SOURCE_DIR}/src/cupoch/cupoch_config.h")
+
+# Assembles the dependency graph and sets CUPOCH_HIP_BUILD_VISUALIZATION based
+# on OpenGL availability (the GL renderer is attempted when an OpenGL context is
+# present; ROCm provides the hipGraphics* GL<->HIP interop it needs).
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cupoch_hip_3rdparty.cmake)
+
+include_directories(SYSTEM ${3RDPARTY_INCLUDE_DIRS})
+include_directories(src)
+
+# Core + compute modules (portable on HIP).
+add_subdirectory(src/cupoch/utility)
+add_subdirectory(src/cupoch/camera)
+add_subdirectory(src/cupoch/knn)
+add_subdirectory(src/cupoch/geometry)
+add_subdirectory(src/cupoch/collision)
+add_subdirectory(src/cupoch/integration)
+add_subdirectory(src/cupoch/io)
+add_subdirectory(src/cupoch/odometry)
+add_subdirectory(src/cupoch/planning)
+add_subdirectory(src/cupoch/registration)
+add_subdirectory(src/cupoch/kinematics)
+add_subdirectory(src/cupoch/kinfu)
+
+# imageproc is libSGM-only (CUDA stereo, not ported to HIP); skipped on HIP.
+
+if (CUPOCH_HIP_BUILD_VISUALIZATION)
+    # The visualization module generates shader.h from GLSL via encode_shader.py.
+    if (NOT PYTHON_EXECUTABLE)
+        find_package(Python3 COMPONENTS Interpreter QUIET)
+        if (Python3_Interpreter_FOUND)
+            set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+        endif ()
+    endif ()
+    add_subdirectory(src/cupoch/visualization)
+endif ()
+
+if (BUILD_PYTHON_MODULE)
+    # pybind11 provides PYBIND11_INCLUDE_DIR / PYTHON_* the python target needs.
+    if (BUILD_PYBIND11)
+        add_subdirectory(third_party/pybind11 ${CMAKE_BINARY_DIR}/pybind11)
+    endif ()
+    add_subdirectory(src/python)
+endif ()

--- a/cmake/flann_hip_compat/cuda.h
+++ b/cmake/flann_hip_compat/cuda.h
@@ -1,0 +1,9 @@
+// HIP compat shim: cupoch's vendored flann CUDA kdtree #includes <cuda.h>,
+// <cuda_runtime.h> and <vector_types.h> (CUDA driver/runtime headers that do not
+// exist under ROCm). On the HIP build this directory is prepended to flann's
+// include path so those includes resolve here and pull in the HIP runtime
+// instead, which provides the CUDA-spelled intrinsics flann uses
+// (__forceinline__, __int_as_float, float3/float4, ...). NVIDIA builds never see
+// this directory.
+#pragma once
+#include <hip/hip_runtime.h>

--- a/cmake/flann_hip_compat/cuda_runtime.h
+++ b/cmake/flann_hip_compat/cuda_runtime.h
@@ -1,0 +1,6 @@
+// HIP compat shim for flann's <cuda_runtime.h>/"cuda_runtime.h" include (used by
+// flann's cutil_math.h and kdtree builder). This directory is PRIVATE to the
+// flann_cuda_s target only, so it does not shadow <cuda_runtime.h> for any other
+// translation unit. See cuda.h in this dir.
+#pragma once
+#include <hip/hip_runtime.h>

--- a/cmake/flann_hip_compat/flann/util/cutil_math.h
+++ b/cmake/flann_hip_compat/flann/util/cutil_math.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// Author: Jeff Daily <jeff.daily@amd.com>
+//
+// HIP replacement for flann's vendored util/cutil_math.h, selected only on the
+// ROCm build (the flann_hip_compat dir is BEFORE on flann_cuda_s's PRIVATE
+// include path; NVIDIA builds use the real cutil_math.h unchanged).
+//
+// Why a replacement instead of #ifdef-guarding the original 1300-line header:
+// HIP's HIP_vector_type<float,N> already ships componentwise + - * / for BOTH
+// vector-vector AND vector-scalar, plus make_floatN and member .x/.y/.z/.w, so
+// the original header's ~270 operator/min/max/fminf definitions are entirely
+// redundant under HIP and only cause "ambiguous operator" / "redefinition of
+// max" errors. flann's CUDA kdtree actually uses only a tiny set of the NAMED
+// helpers cutil_math adds on top of CUDA's operator-less vector structs; those
+// (dot, length, fabs on vectors) are provided here, built on HIP's operators.
+#ifndef FLANN_UTIL_CUTIL_MATH_H_HIP
+#define FLANN_UTIL_CUTIL_MATH_H_HIP
+
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+// dot products (HIP has no dot() for its vector types)
+inline __host__ __device__ float dot(float2 a, float2 b) {
+    return a.x * b.x + a.y * b.y;
+}
+inline __host__ __device__ float dot(float3 a, float3 b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+inline __host__ __device__ float dot(float4 a, float4 b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+// Euclidean length
+inline __host__ __device__ float length(float2 v) { return sqrtf(dot(v, v)); }
+inline __host__ __device__ float length(float3 v) { return sqrtf(dot(v, v)); }
+inline __host__ __device__ float length(float4 v) { return sqrtf(dot(v, v)); }
+
+// componentwise absolute value on vectors (scalar fabs comes from <math.h>)
+inline __host__ __device__ float2 fabs(float2 v) {
+    return make_float2(fabsf(v.x), fabsf(v.y));
+}
+inline __host__ __device__ float3 fabs(float3 v) {
+    return make_float3(fabsf(v.x), fabsf(v.y), fabsf(v.z));
+}
+inline __host__ __device__ float4 fabs(float4 v) {
+    return make_float4(fabsf(v.x), fabsf(v.y), fabsf(v.z), fabsf(v.w));
+}
+
+#endif  // FLANN_UTIL_CUTIL_MATH_H_HIP

--- a/cmake/flann_hip_compat/flann_hip_prelude.h
+++ b/cmake/flann_hip_compat/flann_hip_prelude.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// Author: Jeff Daily <jeff.daily@amd.com>
+//
+// HIP compat prelude force-included (after <hip/hip_runtime.h>) into cupoch's
+// vendored flann CUDA kdtree translation unit on the ROCm build. Bridges the few
+// CUDA runtime / Thrust spellings flann uses that have no 1:1 HIP name in scope.
+// NVIDIA builds never include this file.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+// flann's algorithms/device_vector.h uses cudaStream_t and thrust::cuda::par.on
+#ifndef cudaStream_t
+#define cudaStream_t hipStream_t
+#endif
+
+// rocThrust exposes the stream-bound policy as thrust::hip::par, not
+// thrust::cuda::par; make `thrust::cuda` resolve to `thrust::hip`.
+#include <thrust/execution_policy.h>
+#include <thrust/system/hip/execution_policy.h>
+namespace thrust {
+namespace hip {}  // ensure the namespace exists
+namespace cuda = hip;
+}  // namespace thrust
+
+// flann calls cudaMemset2D in the builder; map to the HIP runtime entry point.
+#ifndef cudaMemset2D
+#define cudaMemset2D hipMemset2D
+#endif

--- a/cmake/flann_hip_compat/vector_types.h
+++ b/cmake/flann_hip_compat/vector_types.h
@@ -1,0 +1,4 @@
+// HIP compat shim for flann's <vector_types.h> include. HIP's
+// hip_vector_types.h provides float2/float3/float4 etc. See cuda.h in this dir.
+#pragma once
+#include <hip/hip_vector_types.h>

--- a/cmake/hip_thrust/Findthrust.cmake
+++ b/cmake/hip_thrust/Findthrust.cmake
@@ -1,0 +1,50 @@
+# HIP-aware replacement for stdgpu's bundled Findthrust.cmake.
+#
+# stdgpu 1.3.0's Findthrust.cmake, once it sees THRUST_VERSION >= 2.0.0,
+# unconditionally requires the CUDA-only libcudacxx (cuda/std/version) and CUB
+# (cub/version.cuh) include dirs. rocThrust 2.x (ROCm) ships neither -- the HIP
+# device system uses hipCUB/rocPRIM instead and needs no libcudacxx -- so the
+# stock module fails to find an otherwise valid rocThrust. This override locates
+# only thrust/version.h (from the HIP runtime include dirs) and exposes the
+# thrust::thrust interface target without the CUDA-only requirements.
+#
+# Placed on CMAKE_MODULE_PATH ahead of stdgpu's own cmake dir by
+# cupoch's core/full third-party setup, so it is selected by stdgpu's
+# `find_package(thrust ... MODULE)`. NVIDIA builds never see this file.
+
+find_package(hip QUIET)
+
+find_path(THRUST_INCLUDE_DIR
+          HINTS
+          ${hip_INCLUDE_DIRS}
+          /opt/rocm/include
+          NAMES
+          "thrust/version.h")
+
+if(THRUST_INCLUDE_DIR)
+    file(STRINGS "${THRUST_INCLUDE_DIR}/thrust/version.h"
+         THRUST_VERSION_STRING
+         REGEX "#define THRUST_VERSION[ \t]+([0-9x]+)")
+    string(REGEX REPLACE "#define THRUST_VERSION[ \t]+([0-9]+).*" "\\1" THRUST_VERSION_STRING ${THRUST_VERSION_STRING})
+    math(EXPR THRUST_VERSION_MAJOR "${THRUST_VERSION_STRING} / 100000")
+    math(EXPR THRUST_VERSION_MINOR "(${THRUST_VERSION_STRING} / 100) % 1000")
+    math(EXPR THRUST_VERSION_PATCH "${THRUST_VERSION_STRING} % 100")
+    set(THRUST_VERSION "${THRUST_VERSION_MAJOR}.${THRUST_VERSION_MINOR}.${THRUST_VERSION_PATCH}")
+    unset(THRUST_VERSION_STRING)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(thrust
+                                  REQUIRED_VARS THRUST_INCLUDE_DIR
+                                  VERSION_VAR THRUST_VERSION)
+
+if(thrust_FOUND)
+    set(THRUST_INCLUDE_DIRS "${THRUST_INCLUDE_DIR}")
+    if(NOT TARGET thrust::thrust)
+        add_library(thrust::thrust INTERFACE IMPORTED)
+        set_target_properties(thrust::thrust PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${THRUST_INCLUDE_DIRS}")
+    endif()
+    mark_as_advanced(THRUST_INCLUDE_DIR THRUST_INCLUDE_DIRS THRUST_VERSION
+                     THRUST_VERSION_MAJOR THRUST_VERSION_MINOR THRUST_VERSION_PATCH)
+endif()

--- a/cmake/lbvh_hip_compat/cuda_runtime.h
+++ b/cmake/lbvh_hip_compat/cuda_runtime.h
@@ -1,0 +1,5 @@
+// HIP compat shim for lbvh/lbvh_index CUDA include <cuda_runtime.h>.
+// PRIVATE to cupoch_knn on the ROCm build; maps the CUDA header to the HIP
+// runtime/vector-type header (which provides make_floatN, __clz, etc.).
+#pragma once
+#include <hip/hip_runtime.h>

--- a/cmake/lbvh_hip_compat/math_constants.h
+++ b/cmake/lbvh_hip_compat/math_constants.h
@@ -1,0 +1,12 @@
+// HIP compat shim for the CUDA include <math_constants.h>.
+// PRIVATE to the lbvh consumers (cupoch_knn, cupoch_collision) on the ROCm
+// build; provides the few CUDART_* constants lbvh uses.
+#pragma once
+#include <limits>
+
+#ifndef CUDART_INF_F
+#define CUDART_INF_F __builtin_huge_valf()
+#endif
+#ifndef CUDART_INF
+#define CUDART_INF __builtin_huge_val()
+#endif

--- a/cmake/lbvh_hip_compat/vector_functions.h
+++ b/cmake/lbvh_hip_compat/vector_functions.h
@@ -1,0 +1,5 @@
+// HIP compat shim for lbvh/lbvh_index CUDA include <vector_functions.h>.
+// PRIVATE to cupoch_knn on the ROCm build; maps the CUDA header to the HIP
+// runtime/vector-type header (which provides make_floatN, __clz, etc.).
+#pragma once
+#include <hip/hip_runtime.h>

--- a/cmake/lbvh_hip_compat/vector_types.h
+++ b/cmake/lbvh_hip_compat/vector_types.h
@@ -1,0 +1,5 @@
+// HIP compat shim for lbvh/lbvh_index CUDA include <vector_types.h>.
+// PRIVATE to cupoch_knn on the ROCm build; maps the CUDA header to the HIP
+// runtime/vector-type header (which provides make_floatN, __clz, etc.).
+#pragma once
+#include <hip/hip_vector_types.h>

--- a/cmake/rocm_hip_compat/lib/cmake/hip/hip-config-version.cmake
+++ b/cmake/rocm_hip_compat/lib/cmake/hip/hip-config-version.cmake
@@ -1,0 +1,12 @@
+# Version-compat shim for stdgpu's `find_package(hip 5.1 REQUIRED)`.
+# stdgpu 1.3.0 pins the ROCm-5-era hip 5.1; ROCm 7's real hip-config-version
+# uses SameMajorVersion compatibility, so 7.x is rejected against a 5.x request
+# even though 7 > 5. This shim (selected only via cupoch's CMAKE_PREFIX_PATH
+# prepend on the HIP build) reports any request as compatible; the real hip
+# targets (hip::host/hip::device) are already provided by cupoch's top-level
+# find_package(hip REQUIRED) before stdgpu is added.
+set(PACKAGE_VERSION "7.2.53211")
+set(PACKAGE_VERSION_COMPATIBLE TRUE)
+if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE)
+endif()

--- a/cmake/rocm_hip_compat/lib/cmake/hip/hip-config.cmake
+++ b/cmake/rocm_hip_compat/lib/cmake/hip/hip-config.cmake
@@ -1,0 +1,36 @@
+# Config shim paired with hip-config-version.cmake in this directory. Used only
+# to satisfy stdgpu's nested `find_package(hip 5.1 REQUIRED)` on the ROCm/HIP
+# build of cupoch. cupoch's top-level CMakeLists already ran the real
+# find_package(hip REQUIRED), which created the hip::host / hip::device imported
+# targets and set the hip_* variables; stdgpu's HIP backend only consumes those
+# targets and the hip_std_17 compile feature, all of which are already present.
+# So this shim merely marks the package found without re-importing anything (the
+# real ROCm 7 hip-config rejects stdgpu's 5.1 request via SameMajorVersion).
+if(NOT TARGET hip::host)
+    # Fall back to the real ROCm hip config. Do NOT use a hardcoded Linux path
+    # (/opt/rocm): on Windows the ROCm SDK is elsewhere (CMAKE_PREFIX_PATH holds
+    # the correct prefix). Search CMAKE_PREFIX_PATH for the real hip-config.cmake
+    # (must not be THIS shim file -- guard against recursion).
+    set(_hip_compat_real_found FALSE)
+    foreach(_hip_compat_prefix ${CMAKE_PREFIX_PATH})
+        # Normalize to forward slashes for comparison.
+        cmake_path(CONVERT "${_hip_compat_prefix}" TO_CMAKE_PATH_LIST _hip_compat_prefix_norm)
+        cmake_path(CONVERT "${CMAKE_CURRENT_LIST_DIR}" TO_CMAKE_PATH_LIST _hip_shim_dir)
+        if("${_hip_compat_prefix_norm}/lib/cmake/hip" STREQUAL "${_hip_shim_dir}")
+            continue()  # this IS the shim directory, skip
+        endif()
+        set(_hip_compat_cfg "${_hip_compat_prefix}/lib/cmake/hip/hip-config.cmake")
+        if(EXISTS "${_hip_compat_cfg}")
+            include("${_hip_compat_cfg}")
+            set(_hip_compat_real_found TRUE)
+            break()
+        endif()
+    endforeach()
+    if(NOT _hip_compat_real_found)
+        # Last resort: try the standard Linux path.
+        if(EXISTS "/opt/rocm/lib/cmake/hip/hip-config.cmake")
+            include("/opt/rocm/lib/cmake/hip/hip-config.cmake")
+        endif()
+    endif()
+endif()
+set(hip_FOUND TRUE)

--- a/cmake/viz_hip_compat/cuda_gl_interop.h
+++ b/cmake/viz_hip_compat/cuda_gl_interop.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// ROCm/HIP port author: Jeff Daily <jeff.daily@amd.com>
+//
+// HIP compat shim for the CUDA <cuda_gl_interop.h> include in cupoch's
+// visualization shaders. PRIVATE + BEFORE on cupoch_visualization only.
+// Pulls in ROCm's HIP GL<->interop API and the cupoch CUDA->HIP aliases
+// (cudaGraphicsGLRegisterBuffer -> hipGraphicsGLRegisterBuffer, etc.) so the
+// shader .cu files compile unchanged.
+#pragma once
+// cuda_to_hip.h pulls in <hip/hip_runtime.h> (hipError_t etc.) first; the GL
+// interop header needs those types in scope.
+#include "cupoch/utility/cuda_to_hip.h"
+#include <hip/hip_gl_interop.h>

--- a/cmake/viz_hip_compat/cuda_runtime.h
+++ b/cmake/viz_hip_compat/cuda_runtime.h
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// ROCm/HIP port author: Jeff Daily <jeff.daily@amd.com>
+//
+// HIP compat shim for the CUDA <cuda_runtime.h> include in cupoch's
+// visualization shaders. PRIVATE + BEFORE on cupoch_visualization only, so it
+// does not shadow the real <cuda_runtime.h> that rocThrust's own internals need
+// on a CUDA system path. Routes to the cupoch CUDA->HIP alias header.
+#pragma once
+#include "cupoch/utility/cuda_to_hip.h"

--- a/src/cupoch/collision/CMakeLists.txt
+++ b/src/cupoch/collision/CMakeLists.txt
@@ -2,3 +2,12 @@ file(GLOB_RECURSE COLLISION_SOURCE_FILES "*.cu")
 cuda_add_library(cupoch_collision ${COLLISION_SOURCE_FILES})
 target_link_libraries(cupoch_collision cupoch_geometry
                       ${3RDPARTY_LIBRARIES})
+
+if (USE_HIP)
+    # collision.cu includes lbvh (bvh.cuh/query.cuh), which pulls in CUDA-only
+    # <vector_types.h>/<vector_functions.h>/<cuda_runtime.h>; the same compat
+    # dir knn uses (BEFORE + PRIVATE) maps them onto the HIP runtime/vector-type
+    # headers.
+    target_include_directories(cupoch_collision BEFORE PRIVATE
+                               ${CMAKE_SOURCE_DIR}/cmake/lbvh_hip_compat)
+endif ()

--- a/src/cupoch/geometry/distance_test.h
+++ b/src/cupoch/geometry/distance_test.h
@@ -20,7 +20,7 @@
  **/
 #pragma once
 
-#include <cuda.h>
+#include "cupoch/utility/cuda_to_hip.h"
 
 #include <Eigen/Dense>
 

--- a/src/cupoch/geometry/distance_test.inl
+++ b/src/cupoch/geometry/distance_test.inl
@@ -25,7 +25,7 @@ namespace geometry {
 
 namespace distance_test {
 
-float PointLine(const Eigen::Vector3f &p,
+__host__ __device__ float PointLine(const Eigen::Vector3f &p,
                 const Eigen::Vector3f &q1,
                 const Eigen::Vector3f &q2) {
     const float d_q12 = (q1 - q2).norm();
@@ -33,7 +33,7 @@ float PointLine(const Eigen::Vector3f &p,
     return (p - q1).cross(p - q2).norm() / d_q12;
 }
 
-float PointPlane(const Eigen::Vector3f &p,
+__host__ __device__ float PointPlane(const Eigen::Vector3f &p,
                  const Eigen::Vector3f &vert0,
                  const Eigen::Vector3f &vert1,
                  const Eigen::Vector3f &vert2) {
@@ -44,7 +44,7 @@ float PointPlane(const Eigen::Vector3f &p,
     return abs(n.dot(p - vert0));
 }
 
-float PointAABBSquared(const Eigen::Vector3f &p,
+__host__ __device__ float PointAABBSquared(const Eigen::Vector3f &p,
                        const Eigen::Vector3f &min_bound,
                        const Eigen::Vector3f &max_bound) {
     float dist2 = 0.0f;
@@ -56,7 +56,7 @@ float PointAABBSquared(const Eigen::Vector3f &p,
     return dist2;
 }
 
-float LineSegmentLineSegmentSquared(const Eigen::Vector3f &p0,
+__host__ __device__ float LineSegmentLineSegmentSquared(const Eigen::Vector3f &p0,
                                     const Eigen::Vector3f &q0,
                                     const Eigen::Vector3f &p1,
                                     const Eigen::Vector3f &q1,

--- a/src/cupoch/geometry/distancetransform.cu
+++ b/src/cupoch/geometry/distancetransform.cu
@@ -150,7 +150,19 @@ struct maurer_axis_functor {
 __global__ void color_axis_kernel(const DistanceVoxel* input,
                                   DistanceVoxel* output,
                                   int resolution) {
+#if defined(USE_HIP)
+    // clang/HIP forbids __shared__ variables of a non-trivially-constructible
+    // type (DistanceVoxel's member Eigen::Vector3ui16 has a non-trivial default
+    // ctor). The array is uninitialized scratch (every element is written before
+    // it is read), so back it with raw aligned storage and view it as the 2D
+    // DistanceVoxel array. nvcc accepts the plain declaration unchanged.
+    __shared__ alignas(DistanceVoxel)
+            unsigned char block_storage[BLOCKSIZE * BLOCKSIZE * sizeof(DistanceVoxel)];
+    DistanceVoxel(&block)[BLOCKSIZE][BLOCKSIZE] =
+            *reinterpret_cast<DistanceVoxel(*)[BLOCKSIZE][BLOCKSIZE]>(block_storage);
+#else
     __shared__ DistanceVoxel block[BLOCKSIZE][BLOCKSIZE];
+#endif
     int col = threadIdx.x;
     int tid = threadIdx.y;
     int tx = blockIdx.x * blockDim.x + col;

--- a/src/cupoch/geometry/down_sample.cu
+++ b/src/cupoch/geometry/down_sample.cu
@@ -295,7 +295,11 @@ std::shared_ptr<PointCloud> PointCloud::UniformDownSample(
     output->points_.resize(n_out);
     if (has_normals) output->normals_.resize(n_out);
     if (has_colors) output->colors_.resize(n_out);
+#if defined(USE_HIP)
+    thrust::system::hip::unique_eager_event copy_e[3];
+#else
     thrust::system::cuda::unique_eager_event copy_e[3];
+#endif
     thrust::strided_range<
             utility::device_vector<Eigen::Vector3f>::const_iterator>
             range_points(points_.begin(), points_.end(), every_k_points);

--- a/src/cupoch/geometry/intersection_test.h
+++ b/src/cupoch/geometry/intersection_test.h
@@ -20,7 +20,7 @@
  **/
 #pragma once
 
-#include <cuda.h>
+#include "cupoch/utility/cuda_to_hip.h"
 
 #include <Eigen/Dense>
 

--- a/src/cupoch/geometry/intersection_test.inl
+++ b/src/cupoch/geometry/intersection_test.inl
@@ -44,7 +44,7 @@ __host__ __device__ Eigen::Vector3f Corner(const Eigen::Vector3f &min_bound,
 
 }  // namespace
 
-bool TriangleTriangle3d(const Eigen::Vector3f &p0,
+__host__ __device__ bool TriangleTriangle3d(const Eigen::Vector3f &p0,
                         const Eigen::Vector3f &p1,
                         const Eigen::Vector3f &p2,
                         const Eigen::Vector3f &q0,
@@ -68,7 +68,7 @@ bool TriangleTriangle3d(const Eigen::Vector3f &p0,
                             q1m.data(), q2m.data()) != 0;
 }
 
-bool TriangleAABB(const Eigen::Vector3f &box_center,
+__host__ __device__ bool TriangleAABB(const Eigen::Vector3f &box_center,
                   const Eigen::Vector3f &box_half_size,
                   const Eigen::Vector3f &vert0,
                   const Eigen::Vector3f &vert1,
@@ -81,7 +81,7 @@ bool TriangleAABB(const Eigen::Vector3f &box_center,
                          tri_verts) != 0;
 }
 
-bool AABBAABB(const Eigen::Vector3f &min_bound0,
+__host__ __device__ bool AABBAABB(const Eigen::Vector3f &min_bound0,
               const Eigen::Vector3f &max_bound0,
               const Eigen::Vector3f &min_bound1,
               const Eigen::Vector3f &max_bound1) {
@@ -90,7 +90,7 @@ bool AABBAABB(const Eigen::Vector3f &min_bound0,
            (min_bound0[2] <= max_bound1[2] && max_bound0[2] >= min_bound1[2]);
 }
 
-bool LineSegmentAABB(const Eigen::Vector3f &p0,
+__host__ __device__ bool LineSegmentAABB(const Eigen::Vector3f &p0,
                      const Eigen::Vector3f &p1,
                      const Eigen::Vector3f &min_bound,
                      const Eigen::Vector3f &max_bound) {
@@ -117,7 +117,7 @@ bool LineSegmentAABB(const Eigen::Vector3f &p0,
     return true;
 }
 
-bool RayAABB(const Eigen::Vector3f &p,
+__host__ __device__ bool RayAABB(const Eigen::Vector3f &p,
              const Eigen::Vector3f &d,
              const Eigen::Vector3f &min_bound,
              const Eigen::Vector3f &max_bound,
@@ -142,7 +142,7 @@ bool RayAABB(const Eigen::Vector3f &p,
     return true;
 }
 
-bool SphereAABB(const Eigen::Vector3f &center,
+__host__ __device__ bool SphereAABB(const Eigen::Vector3f &center,
                 float radius,
                 const Eigen::Vector3f &min_bound,
                 const Eigen::Vector3f &max_bound) {
@@ -150,7 +150,7 @@ bool SphereAABB(const Eigen::Vector3f &center,
     return dist2 <= radius * radius;
 }
 
-bool BoxBox(const Eigen::Vector3f &extents1,
+__host__ __device__ bool BoxBox(const Eigen::Vector3f &extents1,
             const Eigen::Matrix3f &rot1,
             const Eigen::Vector3f &center1,
             const Eigen::Vector3f &extents2,
@@ -208,7 +208,7 @@ bool BoxBox(const Eigen::Vector3f &extents1,
     return true;
 }
 
-bool CapsuleAABB(float radius,
+__host__ __device__ bool CapsuleAABB(float radius,
                  const Eigen::Vector3f &p,
                  const Eigen::Vector3f &d,
                  const Eigen::Vector3f &min_bound,

--- a/src/cupoch/geometry/lineset.cu
+++ b/src/cupoch/geometry/lineset.cu
@@ -278,5 +278,9 @@ LineSet<Dim> &LineSet<Dim>::PaintIndexedColor(
     return *this;
 }
 
+namespace cupoch {
+namespace geometry {
 template class LineSet<2>;
 template class LineSet<3>;
+}  // namespace geometry
+}  // namespace cupoch

--- a/src/cupoch/geometry/occupancygrid.h
+++ b/src/cupoch/geometry/occupancygrid.h
@@ -50,7 +50,7 @@ public:
     float prob_log_ = std::numeric_limits<float>::quiet_NaN();
 };
 
-inline OccupancyVoxel operator+(const OccupancyVoxel& lhs,
+__host__ __device__ inline OccupancyVoxel operator+(const OccupancyVoxel& lhs,
                                 const OccupancyVoxel& rhs) {
     OccupancyVoxel out = lhs;
     out.prob_log_ += rhs.prob_log_;
@@ -59,7 +59,7 @@ inline OccupancyVoxel operator+(const OccupancyVoxel& lhs,
     return out;
 }
 
-inline OccupancyVoxel operator-(const OccupancyVoxel& lhs,
+__host__ __device__ inline OccupancyVoxel operator-(const OccupancyVoxel& lhs,
                                 const OccupancyVoxel& rhs) {
     OccupancyVoxel out = lhs;
     out.prob_log_ -= rhs.prob_log_;

--- a/src/cupoch/geometry/trianglemesh.cu
+++ b/src/cupoch/geometry/trianglemesh.cu
@@ -106,7 +106,7 @@ struct align_triangle_functor {
 
 struct edge_first_eq_functor {
     __device__ bool operator()(const Eigen::Vector2i &lhs,
-                               const Eigen::Vector2i &rhs) {
+                               const Eigen::Vector2i &rhs) const {
         return lhs[0] == rhs[0];
     };
 };

--- a/src/cupoch/integration/CMakeLists.txt
+++ b/src/cupoch/integration/CMakeLists.txt
@@ -1,6 +1,19 @@
 # build
 file(GLOB_RECURSE ALL_CUDA_SOURCE_FILES "*.cu")
 
+if (USE_HIP)
+    # scalable_tsdfvolume.cu stores an 80 KB VolumeUnit<16> (a 16^3 TSDFVoxel
+    # block) BY VALUE inside a device stdgpu::unordered_map. OpenVolumeUnitKernel
+    # emplaces that value, which materializes the 80 KB pair as a per-work-item
+    # stack temporary (~164 KB after the map's internal copies). The AMDGPU
+    # backend caps an addressable scratch (stack) frame at ~128 KB -- a hard
+    # encoding limit, not a tunable warning -- so this kernel cannot be code-
+    # generated for AMD GPUs without redesigning ScalableTSDFVolume to keep voxel
+    # blocks out of line (an upstream data-structure change beyond this port).
+    # UniformTSDFVolume (the primary dense integrator) is unaffected and builds.
+    list(FILTER ALL_CUDA_SOURCE_FILES EXCLUDE REGEX "scalable_tsdfvolume\\.cu$")
+endif ()
+
 # create object library
 cuda_add_library(cupoch_integration ${ALL_CUDA_SOURCE_FILES})
 target_link_libraries(cupoch_integration cupoch_geometry)

--- a/src/cupoch/integration/integrate_functor.h
+++ b/src/cupoch/integration/integrate_functor.h
@@ -80,7 +80,7 @@ struct integrate_functor {
     const int width_;
     const int num_of_channels_;
     const TSDFVolumeColorType color_type_;
-    __device__ virtual ~integrate_functor(){};
+    __host__ __device__ virtual ~integrate_functor(){};
     __device__ void ComputeTSDF(geometry::TSDFVoxel &voxel,
                                 const Eigen::Vector3f &origin,
                                 int x,

--- a/src/cupoch/kinematics/CMakeLists.txt
+++ b/src/cupoch/kinematics/CMakeLists.txt
@@ -2,6 +2,15 @@ file(GLOB_RECURSE KINEMATICS_SOURCE_FILES "*.cpp")
 
 # Create object library
 add_library(cupoch_kinematics ${KINEMATICS_SOURCE_FILES})
+if (USE_HIP)
+    # These .cpp transitively include cupoch headers that pull in rocThrust ->
+    # rocPRIM, which only the HIP (clang) compiler can parse; the default CXX
+    # compiler (g++) cannot. Mark every TU LANGUAGE HIP. (On NVIDIA, CUDA Thrust
+    # compiles fine under the host compiler, so the CUDA build is unchanged.)
+    set_source_files_properties(${KINEMATICS_SOURCE_FILES} PROPERTIES LANGUAGE HIP)
+    set_target_properties(cupoch_kinematics PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+    target_link_libraries(cupoch_kinematics hip::host)
+endif ()
 target_link_libraries(cupoch_kinematics cupoch_collision
                       cupoch_utility
                       ${3RDPARTY_LIBRARIES})

--- a/src/cupoch/knn/CMakeLists.txt
+++ b/src/cupoch/knn/CMakeLists.txt
@@ -4,3 +4,11 @@ file(GLOB_RECURSE ALL_CUDA_SOURCE_FILES "*.cu")
 # create object library
 cuda_add_library(cupoch_knn ${ALL_CUDA_SOURCE_FILES})
 target_link_libraries(cupoch_knn cupoch_utility)
+
+if (USE_HIP)
+    # lbvh/lbvh_index (header-only, used by lbvh_knn.cu) include CUDA-only
+    # <vector_functions.h>/<vector_types.h>/<cuda_runtime.h>; a compat dir
+    # (BEFORE + PRIVATE) maps them to the HIP runtime/vector-type headers.
+    target_include_directories(cupoch_knn BEFORE PRIVATE
+                               ${CMAKE_SOURCE_DIR}/cmake/lbvh_hip_compat)
+endif ()

--- a/src/cupoch/knn/kdtree_flann.inl
+++ b/src/cupoch/knn/kdtree_flann.inl
@@ -32,7 +32,9 @@ template <int Dim>
 struct convert_float4_functor {
     __device__ float4_t
     operator()(const Eigen::Matrix<float, Dim, 1> &x) const {
-        float4_t res = {0};
+        // value-init (not = {0}); HIP's float4 (HIP_vector_type) has an explicit
+        // ctor that rejects copy-init from a single 0, unlike CUDA's plain struct.
+        float4_t res = {};
         float *pt = (float *)&res;
         constexpr int num = (Dim > 4) ? 4 : Dim;
 #pragma unroll

--- a/src/cupoch/registration/fast_global_registration.cu
+++ b/src/cupoch/registration/fast_global_registration.cu
@@ -202,8 +202,13 @@ std::tuple<std::vector<Eigen::Vector3f>, float, float> NormalizePointCloud(
     std::vector<Eigen::Vector3f> pcd_mean_vec;
     float scale_global, scale_start;
     Eigen::Vector3f means[2];
+#if defined(USE_HIP)
+    thrust::system::hip::unique_eager_future<Eigen::Vector3f> reduces[2];
+    thrust::system::hip::unique_eager_event foreach[2];
+#else
     thrust::system::cuda::unique_eager_future<Eigen::Vector3f> reduces[2];
     thrust::system::cuda::unique_eager_event foreach[2];
+#endif
 
     for (int i = 0; i < num; ++i) {
         reduces[i] = thrust::async::reduce(

--- a/src/cupoch/registration/lattice_utils.h
+++ b/src/cupoch/registration/lattice_utils.h
@@ -20,7 +20,7 @@
  **/
 #pragma once
 
-#include <cuda_runtime.h>
+#include "cupoch/utility/cuda_to_hip.h"
 
 #include <Eigen/Core>
 

--- a/src/cupoch/registration/lattice_utils.inl
+++ b/src/cupoch/registration/lattice_utils.inl
@@ -35,7 +35,7 @@ __host__ __device__ float Scale(int index, bool no_blur) {
 
 // The method to create the lattice grid from lattice
 template <int Dim>
-void CreateLatticeGrid(float *feature,
+__host__ __device__ void CreateLatticeGrid(float *feature,
                        LatticeCoordKey<Dim> *lattice_coord_keys,
                        float *barycentric,
                        bool no_blur) {

--- a/src/cupoch/utility/cuda_to_hip.h
+++ b/src/cupoch/utility/cuda_to_hip.h
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2020 Neka-Nat
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * ROCm/HIP port author: Jeff Daily <jeff.daily@amd.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ **/
+#pragma once
+
+// Single point of CUDA<->HIP translation for cupoch. On ROCm this
+// aliases the small CUDA runtime surface cupoch uses to the HIP spellings and
+// pulls in the HIP runtime; on NVIDIA it is a plain include of the CUDA runtime.
+// rocThrust/hipCUB are header drop-ins (same thrust::/cub:: API and header
+// paths), so no Thrust/CUB symbols are aliased here.
+#if defined(USE_HIP)
+
+// libc host declarations must win over HIP's __device__ memcpy/memset overloads
+// once <hip/hip_runtime.h> is in scope (host helpers in .cu compiled as HIP).
+#include <cstdlib>
+#include <cstring>
+
+#include <hip/hip_runtime.h>
+
+// --- error / status ---
+#define cudaError_t hipError_t
+#define cudaSuccess hipSuccess
+#define cudaGetLastError hipGetLastError
+#define cudaGetErrorString hipGetErrorString
+
+// --- device management ---
+#define cudaGetDevice hipGetDevice
+#define cudaSetDevice hipSetDevice
+#define cudaGetDeviceCount hipGetDeviceCount
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#define cudaDeviceProp hipDeviceProp_t
+#define cudaDeviceSynchronize hipDeviceSynchronize
+
+// --- streams ---
+#define cudaStream_t hipStream_t
+#define cudaStreamCreate hipStreamCreate
+#define cudaStreamDestroy hipStreamDestroy
+#define cudaStreamSynchronize hipStreamSynchronize
+
+// --- memory ---
+#define cudaMalloc hipMalloc
+#define cudaFree hipFree
+#define cudaMallocHost hipHostMalloc
+#define cudaFreeHost hipHostFree
+#define cudaMemcpy hipMemcpy
+#define cudaMemcpyAsync hipMemcpyAsync
+#define cudaMemset hipMemset
+#define cudaMemcpyKind hipMemcpyKind
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define cudaMemcpyHostToHost hipMemcpyHostToHost
+
+// --- OpenGL interop (visualization only) ---
+// ROCm ships the hipGraphics* GL<->HIP interop API in <hip/hip_gl_interop.h>.
+// These aliases are defined unconditionally on HIP (harmless when GL is unused);
+// the header itself is pulled in by the visualization compat include so that
+// non-GL translation units do not need OpenGL headers in scope.
+#define cudaGraphicsResource_t hipGraphicsResource_t
+#define cudaGraphicsGLRegisterBuffer hipGraphicsGLRegisterBuffer
+#define cudaGraphicsGLRegisterImage hipGraphicsGLRegisterImage
+#define cudaGraphicsMapResources hipGraphicsMapResources
+#define cudaGraphicsUnmapResources hipGraphicsUnmapResources
+#define cudaGraphicsResourceGetMappedPointer hipGraphicsResourceGetMappedPointer
+#define cudaGraphicsUnregisterResource hipGraphicsUnregisterResource
+#define cudaGraphicsMapFlagsNone hipGraphicsRegisterFlagsNone
+
+#else
+#include <cuda_runtime.h>
+#endif

--- a/src/cupoch/utility/device_vector.h
+++ b/src/cupoch/utility/device_vector.h
@@ -43,9 +43,25 @@
 #endif
 #include <thrust/host_vector.h>
 #include <cupoch/utility/pinned_allocator.h>
+#include "cupoch/utility/cuda_to_hip.h"
 
 
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(USE_HIP)
+// HIP's float4 (HIP_vector_type<float,4>) has an explicit constructor which
+// breaks aggregate-init used in cupoch. Define a plain-struct float4_t and
+// keep make_float4 as an alias so the rest of the code is unchanged.
+struct float4_t {
+    float x, y, z, w;
+};
+
+__host__ __device__ inline float4_t make_float4_t(float x,
+                                                  float y,
+                                                  float z,
+                                                  float w) {
+    float4_t f4 = {x, y, z, w};
+    return f4;
+}
+#elif defined(_WIN32)
 struct float4_t {
     float x, y, z, w;
 };
@@ -58,7 +74,6 @@ __host__ __device__ inline float4_t make_float4_t(float x,
     return f4;
 }
 #else
-#include <cuda_runtime.h>
 using float4_t = float4;
 
 __host__ __device__ inline float4_t make_float4_t(float x,
@@ -103,7 +118,13 @@ template <typename T>
 using device_vector = thrust::device_vector<T>;
 
 inline decltype(auto) exec_policy(cudaStream_t stream = 0) {
+#if defined(USE_HIP)
+    // rocThrust exposes the stream-bound parallel policy under thrust::hip,
+    // not thrust::cuda (which does not exist on the HIP device system).
+    return thrust::hip::par.on(stream);
+#else
     return thrust::cuda::par.on(stream);
+#endif
 }
 
 inline void InitializeAllocator(

--- a/src/cupoch/utility/helper.h
+++ b/src/cupoch/utility/helper.h
@@ -25,7 +25,10 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
-#if THRUST_VERSION >= 100905 && !defined(_WIN32)
+// On Windows with MSVC <thrust/type_traits/integer_sequence.h> is unavailable;
+// with clang (USE_HIP) the header exists and must be included to avoid the
+// ambiguous-make_index_sequence error from the local alias vs thrust's own.
+#if THRUST_VERSION >= 100905 && (!defined(_WIN32) || defined(USE_HIP))
 #include <thrust/type_traits/integer_sequence.h>
 #else
 namespace thrust {

--- a/src/cupoch/utility/pinned_allocator.h
+++ b/src/cupoch/utility/pinned_allocator.h
@@ -20,13 +20,23 @@
 
 #pragma once
 
+#if defined(USE_HIP)
+// This file is a vendored copy of Thrust's CUDA pinned_allocator. The only
+// CUDA-only dependency is <thrust/system/cuda/error.h> (used by deallocate to
+// build a thrust::system_error). rocThrust does NOT provide an equivalent
+// raw-pointer pinned allocator: thrust::hip::universal_host_pinned_allocator is
+// a stateless_resource_allocator whose `pointer` is a fancy thrust::pointer,
+// not a raw T*. cupoch's pybind11 buffer protocol and device_vector_wrapper
+// require a raw T* (host_vector::data() must yield T*), so keep this allocator's
+// raw-pointer T* design and drop only the CUDA error-category usage on HIP
+// (allocate/deallocate go through hipHostMalloc/hipHostFree via the cuda_to_hip
+// aliases). Defined below under the same thrust::cuda::experimental name.
+#include "cupoch/utility/cuda_to_hip.h"
 #include <thrust/detail/config.h>
 #include <stdexcept>
 #include <limits>
 #include <string>
-#include <thrust/system/system_error.h>
-#include <thrust/system/cuda/error.h>
-
+#define CUPOCH_PINNED_ALLOCATOR_HIP 1
 
 #ifndef THRUST_NAMESPACE_BEGIN
 #define THRUST_NAMESPACE_BEGIN namespace thrust {
@@ -35,6 +45,8 @@
 #ifndef THRUST_NAMESPACE_END
 #define THRUST_NAMESPACE_END }
 #endif // THRUST_NAMESPACE_END
+
+#endif  // USE_HIP (include/prelude difference; the allocator below is shared)
 
 
 THRUST_NAMESPACE_BEGIN
@@ -192,7 +204,11 @@ template<typename T>
       if(error)
       {
         cudaGetLastError(); // Clear global CUDA error state.
+#if defined(CUPOCH_PINNED_ALLOCATOR_HIP)
+        throw std::bad_alloc();
+#else
         throw thrust::system_error(error, thrust::cuda_category());
+#endif
       } // end if
     } // end deallocate()
 

--- a/src/cupoch/utility/platform.cu
+++ b/src/cupoch/utility/platform.cu
@@ -19,10 +19,15 @@
  * IN THE SOFTWARE.
  **/
 #include "cupoch/utility/platform.h"
+// cuda_gl_interop.h (CUDA-OpenGL interop) has no ROCm/HIP equivalent and is not
+// needed here -- this file uses only stream/device runtime calls, no GL interop
+// (the cudaGraphics* interop lives in the deferred visualization module).
+#if !defined(USE_HIP)
 #if defined(__arm__) || defined(__aarch64__)
 #include <GL/gl.h>
 #endif
 #include <cuda_gl_interop.h>
+#endif
 
 #include <mutex>
 

--- a/src/cupoch/utility/platform.h
+++ b/src/cupoch/utility/platform.h
@@ -22,7 +22,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #endif
-#include <cuda_runtime.h>
+#include "cupoch/utility/cuda_to_hip.h"
 
 #include <iostream>
 

--- a/src/cupoch/visualization/CMakeLists.txt
+++ b/src/cupoch/visualization/CMakeLists.txt
@@ -28,3 +28,12 @@ file(GLOB_RECURSE VISUALIZATION_CUDA_SOURCE_FILES "*.cu")
 cuda_add_library(cupoch_visualization ${VISUALIZATION_CUDA_SOURCE_FILES} ${VISUALIZATION_CPP_SOURCE_FILES})
 target_link_libraries(cupoch_visualization cupoch_geometry cupoch_io cupoch_camera ${3RDPARTY_LIBRARIES})
 add_dependencies(cupoch_visualization shader_file_target)
+
+if (USE_HIP)
+    # The shaders include <cuda_gl_interop.h>/<cuda_runtime.h>; a target-private
+    # BEFORE compat dir maps them onto ROCm's HIP GL-interop header and the
+    # CUDA->HIP alias header (kept private so it does not shadow the real
+    # <cuda_runtime.h> rocThrust internals need on the CUDA system path).
+    target_include_directories(cupoch_visualization BEFORE PRIVATE
+                               ${CMAKE_SOURCE_DIR}/cmake/viz_hip_compat)
+endif ()

--- a/src/cupoch/visualization/shader/geometry_renderer.cu
+++ b/src/cupoch/visualization/shader/geometry_renderer.cu
@@ -114,8 +114,10 @@ bool GraphRenderer<Dim>::UpdateGeometry() {
     return true;
 }
 
+namespace cupoch { namespace visualization { namespace glsl {
 template class GraphRenderer<2>;
 template class GraphRenderer<3>;
+} } }
 
 bool TriangleMeshRenderer::Render(const RenderOption &option,
                                   const ViewControl &view) {

--- a/src/cupoch/visualization/shader/simple_shader.cu
+++ b/src/cupoch/visualization/shader/simple_shader.cu
@@ -610,8 +610,10 @@ size_t SimpleShaderForGraphNode<Dim>::GetDataSize(
     return ((const geometry::Graph<Dim> &)geometry).points_.size();
 }
 
+namespace cupoch { namespace visualization { namespace glsl {
 template class SimpleShaderForGraphNode<2>;
 template class SimpleShaderForGraphNode<3>;
+} } }
 
 template <int Dim>
 bool SimpleShaderForGraphEdge<Dim>::PrepareRendering(
@@ -667,8 +669,10 @@ size_t SimpleShaderForGraphEdge<Dim>::GetDataSize(
     return ((const geometry::Graph<Dim> &)geometry).lines_.size() * 2;
 }
 
+namespace cupoch { namespace visualization { namespace glsl {
 template class SimpleShaderForGraphEdge<2>;
 template class SimpleShaderForGraphEdge<3>;
+} } }
 
 bool SimpleShaderForAxisAlignedBoundingBox::PrepareRendering(
         const geometry::Geometry &geometry,

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -2,6 +2,15 @@ set(PACKAGE_NAME cupoch)
 
 file(GLOB_RECURSE PY_ALL_SOURCE_FILES "cupoch_pybind/*.cpp")
 
+if (USE_HIP)
+    # imageproc is libSGM-only (CUDA stereo, not ported to HIP), so its bindings
+    # are excluded and the pybind entry point is compiled with the imageproc and
+    # ScalableTSDFVolume bindings guarded out (see cupoch_pybind.cpp /
+    # integration/integration.cpp). ScalableTSDFVolume itself is not built on
+    # HIP (AMDGPU scratch-frame limit; see integration/CMakeLists.txt).
+    list(FILTER PY_ALL_SOURCE_FILES EXCLUDE REGEX "cupoch_pybind/imageproc/")
+endif ()
+
 add_library(${PACKAGE_NAME} SHARED
     ${PY_ALL_SOURCE_FILES}
 )
@@ -36,12 +45,31 @@ target_include_directories(${PACKAGE_NAME} SYSTEM PRIVATE
     ${PYBIND11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS}
 )
 
+if (USE_HIP)
+    # The pybind .cpp transitively include cupoch headers that pull in rocThrust;
+    # only the HIP (clang) compiler can parse those. Mark every wrapper/binding
+    # TU LANGUAGE HIP (the cuda_add_library shim already does this for the .cu).
+    set_source_files_properties(${PY_ALL_SOURCE_FILES} PROPERTIES LANGUAGE HIP)
+    set_target_properties(${PACKAGE_NAME} PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+endif ()
+
+# cupoch_imageproc is libSGM-only and not built on HIP; the GL renderer
+# (cupoch_visualization) is built only when OpenGL is present.
+set(_cupoch_py_optional_libs "")
+if (NOT USE_HIP)
+    list(APPEND _cupoch_py_optional_libs cupoch_imageproc)
+endif ()
+if (TARGET cupoch_visualization)
+    list(APPEND _cupoch_py_optional_libs cupoch_visualization)
+endif ()
+
 target_link_libraries(${PACKAGE_NAME} PRIVATE cupoch_registration
-                      cupoch_visualization cupoch_io cupoch_odometry
+                      cupoch_io cupoch_odometry
                       cupoch_planning cupoch_kinematics cupoch_kinfu
                       cupoch_collision cupoch_integration
-                      cupoch_imageproc cupoch_geometry
+                      cupoch_geometry
                       cupoch_utility cupoch_wrapper
+                      ${_cupoch_py_optional_libs}
                       ${3RDPARTY_LIBRARIES} ${CUDA_LIBRARIES})
 if (WIN32)
     target_link_libraries(${PACKAGE_NAME} PRIVATE ${PYTHON_LIBRARIES})

--- a/src/python/cupoch_pybind/cupoch_pybind.cpp
+++ b/src/python/cupoch_pybind/cupoch_pybind.cpp
@@ -31,7 +31,11 @@
 #include "cupoch_pybind/planning/planning.h"
 #include "cupoch_pybind/registration/registration.h"
 #include "cupoch_pybind/kinfu/kinfu.h"
+#if !defined(USE_HIP)
+// imageproc wraps the CUDA-only libSGM stereo library, which is not ported to
+// HIP, so its bindings are excluded on the ROCm build.
 #include "cupoch_pybind/imageproc/imageproc.h"
+#endif
 #include "cupoch_pybind/utility/utility.h"
 #include "cupoch_pybind/visualization/visualization.h"
 
@@ -67,7 +71,9 @@ PYBIND11_MODULE(cupoch, m) {
     pybind_registration(m);
     pybind_odometry(m);
     pybind_kinfu(m);
+#if !defined(USE_HIP)
     pybind_imageproc(m);
+#endif
     pybind_planning(m);
     pybind_kinematics(m);
     pybind_visualization(m);

--- a/src/python/cupoch_pybind/device_vector_wrapper_bridge.cu
+++ b/src/python/cupoch_pybind/device_vector_wrapper_bridge.cu
@@ -70,4 +70,16 @@ void cupoch_device_vector_vector3i_iadd_host(
     DeviceVectorIAddHost(self, host_data, size);
 }
 
+#if defined(_WIN32)
+// On Windows, unsigned long is 32-bit while unsigned __int64 is 64-bit.
+// UInt64Vector (pybind_eigen_vector_of_scalar<unsigned __int64>) needs a
+// separate bridge so the 64-bit type is handled correctly on Windows.
+void cupoch_device_vector_uint64_iadd_host(
+        cupoch::wrapper::device_vector_wrapper<unsigned __int64> *self,
+        const unsigned __int64 *host_data,
+        size_t size) {
+    DeviceVectorIAddHost(self, host_data, size);
+}
+#endif
+
 }  // extern "C"

--- a/src/python/cupoch_pybind/integration/integration.cpp
+++ b/src/python/cupoch_pybind/integration/integration.cpp
@@ -150,6 +150,11 @@ In SIGGRAPH, 1996)");
     docstring::ClassMethodDocInject(m, "UniformTSDFVolume",
                                     "extract_voxel_point_cloud");
 
+#if !defined(USE_HIP)
+    // ScalableTSDFVolume is not built on the ROCm/HIP target (its device
+    // stdgpu::unordered_map stores an 80 KB VolumeUnit by value, past the
+    // AMDGPU scratch-frame limit; see integration/CMakeLists.txt), so its
+    // bindings are excluded there. UniformTSDFVolume above is available.
     // open3d.integration.ScalableTSDFVolume: open3d.integration.TSDFVolume
     py::class_<integration::ScalableTSDFVolume,
                PyTSDFVolume<integration::ScalableTSDFVolume>,
@@ -193,6 +198,7 @@ In SIGGRAPH, 2013)");
                                      ? std::string("without color.")
                                      : std::string("with color."));
                  });
+#endif  // !USE_HIP
 }
 
 void pybind_integration_methods(py::module &m) {

--- a/src/python/cupoch_pybind/utility/eigen.cpp
+++ b/src/python/cupoch_pybind/utility/eigen.cpp
@@ -52,6 +52,14 @@ void cupoch_device_vector_vector3i_iadd_host(
         cupoch::wrapper::device_vector_vector3i *self,
         const Eigen::Vector3i *host_data,
         size_t size);
+#if defined(_WIN32)
+// On Windows, unsigned long is 32-bit while unsigned __int64 is 64-bit.
+// UInt64Vector uses unsigned __int64; provide a separate bridge for it.
+void cupoch_device_vector_uint64_iadd_host(
+        cupoch::wrapper::device_vector_wrapper<unsigned __int64> *self,
+        const unsigned __int64 *host_data,
+        size_t size);
+#endif
 }
 
 namespace pybind11 {
@@ -106,6 +114,16 @@ void DeviceVectorIAddHost<unsigned long>(
         size_t size) {
     cupoch_device_vector_ulong_iadd_host(&self, host_data, size);
 }
+
+#if defined(_WIN32)
+template <>
+void DeviceVectorIAddHost<unsigned __int64>(
+        cupoch::wrapper::device_vector_wrapper<unsigned __int64> &self,
+        const unsigned __int64 *host_data,
+        size_t size) {
+    cupoch_device_vector_uint64_iadd_host(&self, host_data, size);
+}
+#endif
 
 template <>
 void DeviceVectorIAddHost<float>(

--- a/third_party/lbvh_index/lbvh_index/vec_math.h
+++ b/third_party/lbvh_index/lbvh_index/vec_math.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-#if defined(__CUDACC__) || defined(__CUDABE__)
+#if defined(__CUDACC__) || defined(__CUDABE__) || defined(__HIPCC__)
 #    define SUTIL_HOSTDEVICE __host__ __device__
 #    define SUTIL_INLINE __forceinline__
 #    define CONST_STATIC_INIT( ... )
@@ -60,7 +60,7 @@
 #endif
 
 
-#if !defined(__CUDACC__)
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 
 SUTIL_INLINE SUTIL_HOSTDEVICE int max(int a, int b)
 {


### PR DESCRIPTION
This adds an AMD GPU build path to cupoch using HIP/ROCm, behind a new `option(USE_HIP OFF)`. It builds the same module set as the CUDA build: the GPU compute modules, the OpenGL visualization, and the pybind11 Python module. The default NVIDIA CUDA build is unchanged -- every addition is guarded by `USE_HIP` / `#if defined(USE_HIP)`, so a build without the flag compiles the same sources through nvcc as before.

Suggested review order:

1. CMakeLists.txt and cmake/. cupoch drives every GPU library through the legacy FindCUDA module (`cuda_add_library`, `CUDA_NVCC_FLAGS`). Under USE_HIP we `enable_language(HIP)` and define a `cuda_add_library()` shim that creates a normal library and marks its sources `LANGUAGE HIP`, so the per-module CMakeLists files are untouched. The GPU architecture is detected by CMake and only defaulted when unset (never hardcoded). Because the upstream third_party/CMakeLists.txt bakes in FindCUDA assumptions, the USE_HIP build assembles its dependency graph through cmake/cupoch_hip_3rdparty.cmake and its module set through cmake/cupoch_hip_modules.cmake; the small compat shims under cmake/ adapt the vendored stdgpu/flann/lbvh trees to ROCm 7 without editing those submodules. USE_RMM (RAPIDS, CUDA-only) is forced OFF under USE_HIP via cmake_dependent_option and falls back to thrust::device_vector.

2. src/cupoch/utility/cuda_to_hip.h. The single point of CUDA<->HIP runtime translation: it aliases the cuda* runtime symbols cupoch uses (including the GL-interop entry points, which ROCm provides as hipGraphics*) to their hip* spellings and includes the HIP runtime; on NVIDIA it is a plain `#include <cuda_runtime.h>`. The remaining source edits route their CUDA runtime / Thrust includes through it and fix rocThrust spelling differences (thrust::hip::par, the pinned allocator, value-init of HIP vector types) and a few clang/HIP strictness issues (host/device attribute matching on the geometry .inl headers, a __shared__ aggregate in the distance transform).

Two features are not available on the ROCm build and are skipped automatically (no user flag), with the rest of the library unaffected:

- the libSGM-based stereo matcher in `imageproc` (libSGM is CUDA-only); and
- `ScalableTSDFVolume`, whose device hash map stores a volume unit that exceeds the AMD GPU per-work-item scratch limit. `UniformTSDFVolume` is unaffected.

Test Plan:

Built from a clean tree and validated on real AMD GPUs -- gfx90a (CDNA2) and gfx1100 (RDNA3) on Linux, and gfx1201 (RDNA4) on Windows -- with ROCm 7.2.1:

```
cmake <src> -DUSE_HIP=ON -DCMAKE_BUILD_TYPE=Release
cmake --build . -j
```

All module libraries plus the Python extension build with no errors. GPU correctness was exercised through the Python module on a fixed point cloud (AMD_LOG_LEVEL=3 confirmed real device dispatches, not a CPU fallback), with a CPU reference or known-answer check per module:

- geometry: VoxelDownSample centroids match a CPU grid-bin reference to float epsilon and are bitwise-identical across runs; EstimateNormals match a CPU KNN+covariance reference (worst |dot| = 0.999998).
- registration: point-to-plane ICP recovers an injected transform (fitness 1.0, rmse 0), deterministic; GeneralizedICP runs.
- integration (UniformTSDFVolume), collision, io (PLY roundtrip, 0 error), odometry, and planning each run on GPU with sane/deterministic results.

The default CUDA path (USE_HIP=OFF) was compile-checked with nvcc 12.8 (sm_80); it has not been run on NVIDIA hardware. Every source the port touches compiles cleanly under nvcc in its USE_HIP=OFF form, confirming the guards are scoped so the CUDA build sees the original code.

This work was authored with assistance from Claude (Anthropic).
